### PR TITLE
point nybb dataset to archive

### DIFF
--- a/geodatasets/json/database.json
+++ b/geodatasets/json/database.json
@@ -747,18 +747,18 @@
 
     "ny": {
         "bb": {
-            "url": "https://data.cityofnewyork.us/api/geospatial/tqmj-j8zm?method=export&format=Original",
+            "url": "https://www.nyc.gov/assets/planning/download/zip/data-maps/open-data/nybb_16a.zip",
             "license": "NA",
             "attribution": "Department of City Planning (DCP)",
             "name": "ny.bb",
-            "description": "The borough boundaries of New York City clipped to the shoreline at mean high tide.",
+            "description": "The borough boundaries of New York City clipped to the shoreline at mean high tide for 2016.",
             "geometry_type": "Polygon",
             "details": "https://data.cityofnewyork.us/City-Government/Borough-Boundaries/tqmj-j8zm",
             "nrows": 5,
             "ncols": 5,
-            "hash": "26257f5a3c06765557b302f36774d4d21acb257aa8f9d4a4694d436432160051",
-            "filename": "nybb_22c.zip",
-            "members": ["nybb_22c/nybb.shp", "nybb_22c/nybb.shx", "nybb_22c/nybb.dbf", "nybb_22c/nybb.prj"]
+            "hash": "a303be17630990455eb079777a6b31980549e9096d66d41ce0110761a7e2f92a",
+            "filename": "nybb_16a.zip",
+            "members": ["nybb_16a/nybb.shp", "nybb_16a/nybb.shx", "nybb_16a/nybb.dbf", "nybb_16a/nybb.prj"]
         }
     },
 

--- a/geodatasets/tests/test_api.py
+++ b/geodatasets/tests/test_api.py
@@ -10,13 +10,13 @@ def test_get_url():
     url = geodatasets.get_url("nybb")
     assert (
         url
-        == "https://data.cityofnewyork.us/api/geospatial/tqmj-j8zm?method=export&format=Original"  # noqa
+        == "https://www.nyc.gov/assets/planning/download/zip/data-maps/open-data/nybb_16a.zip"  # noqa
     )
 
 
 @pytest.mark.request
 def test_get_path():
-    in_cache = pooch.os_cache("geodatasets").joinpath("nybb_22c.zip")
+    in_cache = pooch.os_cache("geodatasets").joinpath("nybb_16a.zip")
     if Path(in_cache).exists():
         os.remove(in_cache)
 
@@ -29,13 +29,13 @@ def test_get_path():
 @pytest.mark.request
 def test_fetch():
     # clear cache
-    for data in ["airbnb.zip", "nybb_22c.zip", "nyc_neighborhoods.zip"]:
+    for data in ["airbnb.zip", "nybb_16a.zip", "nyc_neighborhoods.zip"]:
         in_cache = pooch.os_cache("geodatasets").joinpath(data)
         if Path(in_cache).exists():
             os.remove(in_cache)
 
     geodatasets.fetch("nybb")
-    assert pooch.os_cache("geodatasets").joinpath("nybb_22c.zip").exists()
+    assert pooch.os_cache("geodatasets").joinpath("nybb_16a.zip").exists()
 
     geodatasets.fetch(["geoda airbnb", "geoda atlanta"])
 
@@ -43,6 +43,6 @@ def test_fetch():
         assert pooch.os_cache("geodatasets").joinpath(data).exists()
 
     # cleanup
-    for data in ["airbnb.zip", "nybb_22c.zip", "atlanta_hom.zip"]:
+    for data in ["airbnb.zip", "nybb_16a.zip", "atlanta_hom.zip"]:
         in_cache = pooch.os_cache("geodatasets").joinpath(data)
         os.remove(in_cache)

--- a/geodatasets/tests/test_lib.py
+++ b/geodatasets/tests/test_lib.py
@@ -41,7 +41,6 @@ def test_dir(data1):
 
 
 def test_expect_name_url_attribution():
-
     with pytest.raises(AttributeError, match="`name`, `url`, `hash`, `filename`"):
         Dataset({})
     with pytest.raises(AttributeError, match="`url`, `hash`, `filename`"):
@@ -104,7 +103,7 @@ def test_callable():
     # check that original item dict is not modified
     assert (
         data.ny.bb["hash"]
-        == "26257f5a3c06765557b302f36774d4d21acb257aa8f9d4a4694d436432160051"
+        == "a303be17630990455eb079777a6b31980549e9096d66d41ce0110761a7e2f92a"
     )
 
 


### PR DESCRIPTION
We need to point to an archive to ensure the dataset doesn't get update quarterly which breaks the code when linking to the open data portal directly. Pinning the same version we have in geopandas.