### PR TITLE
ENH: add subset of data available in spData

### DIFF
--- a/geodatasets/json/database.json
+++ b/geodatasets/json/database.json
@@ -1052,6 +1052,32 @@
             "ncols": 9,
             "hash": "4e4c2bfd72e3abfe240155ee6952e8235ed75aa21c39868c360e95e70c39f438",
             "filename": "wheat.gpkg"
+        },
+        "zion": {
+            "url": "https://github.com/Nowosad/spDataLarge/raw/refs/heads/master/inst/vector/zion.gpkg",
+            "license": "CC0",
+            "attribution": "spDataLarge",
+            "name": "spdata.zion",
+            "description": "The borders of Zion National Park",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spDataLarge/reference/zion.gpkg.html",
+            "nrows": 1,
+            "ncols": 12,
+            "hash": "03b8584ae4f4e329c0626749596733e07158cf503b5ae8590af88fa70e9d6290",
+            "filename": "zion.gpkg"
+        },
+        "zion_points": {
+            "url": "https://github.com/Nowosad/spDataLarge/raw/refs/heads/master/inst/vector/zion_points.gpkg",
+            "license": "CC0",
+            "attribution": "spDataLarge",
+            "name": "spdata.zion_points",
+            "description": "Dataset containing 30 randomly located points in the Zion National Park",
+            "geometry_type": "Point",
+            "details": "https://jakubnowosad.com/spDataLarge/reference/zion_points.gpkg.html",
+            "nrows": 30,
+            "ncols": 1,
+            "hash": "c69683c8a1a9775b0b77689ecadbbec0251bdd603633822d0c85282b41fc9bc4",
+            "filename": "zion_points.gpkg"
         }
     }
 }

--- a/geodatasets/json/database.json
+++ b/geodatasets/json/database.json
@@ -25,7 +25,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//atlanta_old/",
             "hash": "a33a76e12168fe84361e60c88a9df4856730487305846c559715c89b1a2b5e09",
             "filename": "atlanta_hom.zip",
-            "members": ["atlanta_hom/atl_hom.geojson"]
+            "members": [
+                "atlanta_hom/atl_hom.geojson"
+            ]
         },
         "cars": {
             "url": "https://geodacenter.github.io/data-and-lab//data/Abandoned_Vehicles_Map.csv",
@@ -52,7 +54,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//charleston-1_old/",
             "hash": "4a4fa9c8dd4231ae0b2f12f24895b8336bcab0c28c48653a967cffe011f63a7c",
             "filename": "CharlestonMSA.zip",
-            "members": ["CharlestonMSA/sc_final_census2.gpkg"]
+            "members": [
+                "CharlestonMSA/sc_final_census2.gpkg"
+            ]
         },
         "charleston2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/CharlestonMSA2.zip",
@@ -66,7 +70,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//charleston2/",
             "hash": "056d5d6e236b5bd95f5aee26c77bbe7d61bd07db5aaf72866c2f545205c1d8d7",
             "filename": "CharlestonMSA2.zip",
-            "members": ["CharlestonMSA2/CharlestonMSA2.gpkg"]
+            "members": [
+                "CharlestonMSA2/CharlestonMSA2.gpkg"
+            ]
         },
         "chicago_health": {
             "url": "https://geodacenter.github.io/data-and-lab//data/comarea.zip",
@@ -93,7 +99,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//commpop/",
             "hash": "1dbebb50c8ea47e2279ea819ef64ba793bdee2b88e4716bd6c6ec0e0d8e0e05b",
             "filename": "chicago_commpop.zip",
-            "members": ["chicago_commpop/chicago_commpop.geojson"]
+            "members": [
+                "chicago_commpop/chicago_commpop.geojson"
+            ]
         },
         "chile_labor": {
             "url": "https://geodacenter.github.io/data-and-lab//data/flma.zip",
@@ -107,7 +115,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//FLMA/",
             "hash": "4777072268d0127b3d0be774f51d0f66c15885e9d3c92bc72c641a72f220796c",
             "filename": "flma.zip",
-            "members": ["flma/FLMA.geojson"]
+            "members": [
+                "flma/FLMA.geojson"
+            ]
         },
         "cincinnati": {
             "url": "https://geodacenter.github.io/data-and-lab//data/walnuthills_updated.zip",
@@ -121,7 +131,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//walnut_hills/",
             "hash": "d6871dd688bd14cf4710a218d721d34f6574456f2a14d5c5cfe5a92054ee9763",
             "filename": "walnuthills_updated.zip",
-            "members": ["walnuthills_updated"]
+            "members": [
+                "walnuthills_updated"
+            ]
         },
         "cleveland": {
             "url": "https://geodacenter.github.io/data-and-lab//data/cleveland.zip",
@@ -148,7 +160,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//grid100/",
             "hash": "5702ba39606044f71d53ae6a83758b81332bd3aa216b7b7b6e1c60dd0e72f476",
             "filename": "grid100.zip",
-            "members": ["grid100/grid100s.gpkg"]
+            "members": [
+                "grid100/grid100s.gpkg"
+            ]
         },
         "groceries": {
             "url": "https://geodacenter.github.io/data-and-lab//data/grocery.zip",
@@ -162,7 +176,12 @@
             "details": "https://geodacenter.github.io/data-and-lab//chicago_sup_vars/",
             "hash": "ead10e53b21efcaa29b798428b93ba2a1c0ba1b28f046265c1737712fa83f88a",
             "filename": "grocery.zip",
-            "members": ["grocery/chicago_sup.shp", "grocery/chicago_sup.dbf", "grocery/chicago_sup.shx", "grocery/chicago_sup.prj"]
+            "members": [
+                "grocery/chicago_sup.shp",
+                "grocery/chicago_sup.dbf",
+                "grocery/chicago_sup.shx",
+                "grocery/chicago_sup.prj"
+            ]
         },
         "guerry": {
             "url": "https://geodacenter.github.io/data-and-lab//data/guerry.zip",
@@ -176,7 +195,12 @@
             "details": "https://geodacenter.github.io/data-and-lab//Guerry/",
             "hash": "80d2b355ad3340fcffa0a28e5cec0698af01067f8059b1a60388d200a653b3e8",
             "filename": "guerry.zip",
-            "members": ["guerry/guerry.shp", "guerry/guerry.dbf", "guerry/guerry.shx", "guerry/guerry.prj"]
+            "members": [
+                "guerry/guerry.shp",
+                "guerry/guerry.dbf",
+                "guerry/guerry.shx",
+                "guerry/guerry.prj"
+            ]
         },
         "health": {
             "url": "https://geodacenter.github.io/data-and-lab//data/income_diversity.zip",
@@ -190,7 +214,12 @@
             "details": "https://geodacenter.github.io/data-and-lab//co_income_diversity_variables/",
             "hash": "eafee1063040258bc080e7b501bdf1438d6e45ba208954d8c2e1a7562142d0a7",
             "filename": "income_diversity.zip",
-            "members": ["income_diversity/income_diversity.shp", "income_diversity/income_diversity.dbf", "income_diversity/income_diversity.shx", "income_diversity/income_diversity.prj"]
+            "members": [
+                "income_diversity/income_diversity.shp",
+                "income_diversity/income_diversity.dbf",
+                "income_diversity/income_diversity.shx",
+                "income_diversity/income_diversity.prj"
+            ]
         },
         "health_indicators": {
             "url": "https://geodacenter.github.io/data-and-lab//data/healthIndicators.zip",
@@ -217,7 +246,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//hickory1/",
             "hash": "4c0804608d303e6e44d51966bb8927b1f5f9e060a9b91055a66478b9039d2b44",
             "filename": "HickoryMSA.zip",
-            "members": ["HickoryMSA/nc_final_census2.geojson"]
+            "members": [
+                "HickoryMSA/nc_final_census2.geojson"
+            ]
         },
         "hickory2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/HickoryMSA2.zip",
@@ -231,7 +262,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//hickory2/",
             "hash": "5e9498e1ff036297c3eea3cc42ac31501680a43b50c71b486799ef9021679d07",
             "filename": "HickoryMSA2.zip",
-            "members": ["HickoryMSA2/HickoryMSA2.geojson"]
+            "members": [
+                "HickoryMSA2/HickoryMSA2.geojson"
+            ]
         },
         "home_sales": {
             "url": "https://geodacenter.github.io/data-and-lab//data/kingcounty.zip",
@@ -245,7 +278,12 @@
             "details": "https://geodacenter.github.io/data-and-lab//KingCounty-HouseSales2015/",
             "hash": "b979f0eb2cef6ebd2c761d552821353f795635eb8db53a95f2815fc46e1f644c",
             "filename": "kingcounty.zip",
-            "members": ["kingcounty/kc_house.shp", "kingcounty/kc_house.dbf", "kingcounty/kc_house.shx", "kingcounty/kc_house.prj"]
+            "members": [
+                "kingcounty/kc_house.shp",
+                "kingcounty/kc_house.dbf",
+                "kingcounty/kc_house.shx",
+                "kingcounty/kc_house.prj"
+            ]
         },
         "houston": {
             "url": "https://geodacenter.github.io/data-and-lab//data/houston_hom.zip",
@@ -259,7 +297,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//houston/",
             "hash": "d3167fd150a1369d9a32b892d3b2a8747043d3d382c3dd81e51f696b191d0d15",
             "filename": "houston_hom.zip",
-            "members": ["houston_hom/hou_hom.geojson"]
+            "members": [
+                "houston_hom/hou_hom.geojson"
+            ]
         },
         "juvenile": {
             "url": "https://geodacenter.github.io/data-and-lab//data/juvenile.zip",
@@ -273,7 +313,11 @@
             "details": "https://geodacenter.github.io/data-and-lab//juvenile/",
             "hash": "811cfcfa613578214d907bfbdd396c6e02261e5cda6d56b25a6f961148de961c",
             "filename": "juvenile.zip",
-            "members": ["juvenile/juvenile.shp", "juvenile/juvenile.shx", "juvenile/juvenile.dbf"]
+            "members": [
+                "juvenile/juvenile.shp",
+                "juvenile/juvenile.shx",
+                "juvenile/juvenile.dbf"
+            ]
         },
         "lansing1": {
             "url": "https://geodacenter.github.io/data-and-lab//data/LansingMSA.zip",
@@ -287,7 +331,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//lansing1/",
             "hash": "724ce3d889fa50e7632d16200cf588d40168d49adaf5bca45049dc1b3758bde1",
             "filename": "LansingMSA.zip",
-            "members": ["LansingMSA/mi_final_census2.geojson"]
+            "members": [
+                "LansingMSA/mi_final_census2.geojson"
+            ]
         },
         "lansing2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/LansingMSA2.zip",
@@ -301,7 +347,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//lansing2/",
             "hash": "7657c05d3bd6090c4d5914cfe5aaf01f694601c1e0c29bc3ecbe9bc523662303",
             "filename": "LansingMSA2.zip",
-            "members": ["LansingMSA2/LansingMSA2.geojson"]
+            "members": [
+                "LansingMSA2/LansingMSA2.geojson"
+            ]
         },
         "lasrosas": {
             "url": "https://geodacenter.github.io/data-and-lab//data/lasrosas.zip",
@@ -315,7 +363,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//lasrosas/",
             "hash": "038d0e82203f2875b50499dbd8498ca9c762ebd8003b2f2203ebc6acada8f8fd",
             "filename": "lasrosas.zip",
-            "members": ["lasrosas/rosas1999.gpkg"]
+            "members": [
+                "lasrosas/rosas1999.gpkg"
+            ]
         },
         "liquor_stores": {
             "url": "https://geodacenter.github.io/data-and-lab//data/liquor.zip",
@@ -329,7 +379,12 @@
             "details": "https://geodacenter.github.io/data-and-lab//liq_chicago/",
             "hash": "6a483a6a7066a000bc97bfe71596cf28834d3088fbc958455b903a0938b3b530",
             "filename": "liquor.zip",
-            "members": ["liq_Chicago.shp", "liq_Chicago.dbf", "liq_Chicago.shx", "liq_Chicago.prj"]
+            "members": [
+                "liq_Chicago.shp",
+                "liq_Chicago.dbf",
+                "liq_Chicago.shx",
+                "liq_Chicago.prj"
+            ]
         },
         "malaria": {
             "url": "https://geodacenter.github.io/data-and-lab//data/malariacolomb.zip",
@@ -343,7 +398,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//colomb_malaria/",
             "hash": "ca77477656829833a4e3e384b02439632fa28bb577610fe5aef9e0b094c41a95",
             "filename": "malariacolomb.zip",
-            "members": ["malariacolomb/colmunic.gpkg"]
+            "members": [
+                "malariacolomb/colmunic.gpkg"
+            ]
         },
         "milwaukee1": {
             "url": "https://geodacenter.github.io/data-and-lab//data/MilwaukeeMSA.zip",
@@ -357,7 +414,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//milwaukee1/",
             "hash": "bf3c9617c872db26ea56f20e82a449f18bb04d8fb76a653a2d3842d465bc122c",
             "filename": "MilwaukeeMSA.zip",
-            "members": ["MilwaukeeMSA/wi_final_census2_random4.gpkg"]
+            "members": [
+                "MilwaukeeMSA/wi_final_census2_random4.gpkg"
+            ]
         },
         "milwaukee2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/MilwaukeeMSA2.zip",
@@ -371,7 +430,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//milwaukee2/",
             "hash": "7f74212d63addb9ab84fac9447ee898498c8fafc284edcffe1f1ac79c2175d60",
             "filename": "MilwaukeeMSA2.zip",
-            "members": ["MilwaukeeMSA2/MilwaukeeMSA2.gpkg"]
+            "members": [
+                "MilwaukeeMSA2/MilwaukeeMSA2.gpkg"
+            ]
         },
         "ncovr": {
             "url": "https://geodacenter.github.io/data-and-lab//data/ncovr.zip",
@@ -385,7 +446,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//ncovr/",
             "hash": "e8cb04e6da634c6cd21808bd8cfe4dad6e295b22e8d40cc628e666887719cfe9",
             "filename": "ncovr.zip",
-            "members": ["ncovr/NAT.gpkg"]
+            "members": [
+                "ncovr/NAT.gpkg"
+            ]
         },
         "natregimes": {
             "url": "https://geodacenter.github.io/data-and-lab//data/natregimes.zip",
@@ -412,7 +475,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//ndvi/",
             "hash": "a89459e50a4495c24ead1d284930467ed10eb94829de16a693a9fa89dea2fe22",
             "filename": "ndvi.zip",
-            "members": ["ndvi/ndvigrid.gpkg"]
+            "members": [
+                "ndvi/ndvigrid.gpkg"
+            ]
         },
         "nepal": {
             "url": "https://geodacenter.github.io/data-and-lab//data/nepal.zip",
@@ -491,7 +556,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//orlando1/",
             "hash": "e98ea5b9ffaf3e421ed437f665c739d1e92d9908e2b121c75ac02ecf7de2e254",
             "filename": "OrlandoMSA.zip",
-            "members": ["OrlandoMSA/orlando_final_census2.gpkg"]
+            "members": [
+                "OrlandoMSA/orlando_final_census2.gpkg"
+            ]
         },
         "orlando2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/OrlandoMSA2.zip",
@@ -505,7 +572,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//orlando2/",
             "hash": "4cd8c3469cb7edea5f0fb615026192e12b1d4b50c22b28345adf476bc85d0f03",
             "filename": "OrlandoMSA2.zip",
-            "members": ["OrlandoMSA2/OrlandoMSA2.gpkg"]
+            "members": [
+                "OrlandoMSA2/OrlandoMSA2.gpkg"
+            ]
         },
         "oz9799": {
             "url": "https://geodacenter.github.io/data-and-lab//data/oz9799.zip",
@@ -519,7 +588,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//oz96/",
             "hash": "1ecc7c46f5f42af6057dedc1b73f56b576cb9716d2c08d23cba98f639dfddb82",
             "filename": "oz9799.zip",
-            "members": ["oz9799/oz9799.csv"]
+            "members": [
+                "oz9799/oz9799.csv"
+            ]
         },
         "phoenix_acs": {
             "url": "https://geodacenter.github.io/data-and-lab//data/phx2.zip",
@@ -533,7 +604,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//phx/",
             "hash": "b2f6e196bacb6f3fe1fc909af482e7e75b83d1f8363fc73038286364c13334ee",
             "filename": "phx2.zip",
-            "members": ["phx/phx.gpkg"]
+            "members": [
+                "phx/phx.gpkg"
+            ]
         },
         "police": {
             "url": "https://geodacenter.github.io/data-and-lab//data/police.zip",
@@ -547,7 +620,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//police/",
             "hash": "596270d62dea8207001da84883ac265591e5de053f981c7491e7b5c738e9e9ff",
             "filename": "police.zip",
-            "members": ["police/police.gpkg"]
+            "members": [
+                "police/police.gpkg"
+            ]
         },
         "sacramento1": {
             "url": "https://geodacenter.github.io/data-and-lab//data/sacramento.zip",
@@ -561,7 +636,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//sacramento1/",
             "hash": "72ddeb533cf2917dc1f458add7c6042b93c79b31316ae2d22f1c855a9da275f9",
             "filename": "sacramento.zip",
-            "members": ["sacramento/sacramentot2.gpkg"]
+            "members": [
+                "sacramento/sacramentot2.gpkg"
+            ]
         },
         "sacramento2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/SacramentoMSA2.zip",
@@ -575,7 +652,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//sacramento2/",
             "hash": "3f6899efd371804ea8bfaf3cdfd3ed4753ea4d009fed38a57c5bbf442ab9468b",
             "filename": "SacramentoMSA2.zip",
-            "members": ["SacramentoMSA2/SacramentoMSA2.gpkg"]
+            "members": [
+                "SacramentoMSA2/SacramentoMSA2.gpkg"
+            ]
         },
         "savannah1": {
             "url": "https://geodacenter.github.io/data-and-lab//data/SavannahMSA.zip",
@@ -589,7 +668,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//savannah1/",
             "hash": "df48c228776d2122c38935b2ebbf4cbb90c0bacc68df01161e653aab960e4208",
             "filename": "SavannahMSA.zip",
-            "members": ["SavannahMSA/ga_final_census2.gpkg"]
+            "members": [
+                "SavannahMSA/ga_final_census2.gpkg"
+            ]
         },
         "savannah2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/SavannahMSA2.zip",
@@ -603,7 +684,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//savannah2/",
             "hash": "5b22b84a8665434cb91e800a039337f028b888082b8ef7a26d77eb6cc9aea8c1",
             "filename": "SavannahMSA2.zip",
-            "members": ["SavannahMSA2/SavannahMSA2.gpkg"]
+            "members": [
+                "SavannahMSA2/SavannahMSA2.gpkg"
+            ]
         },
         "seattle1": {
             "url": "https://geodacenter.github.io/data-and-lab//data/SeattleMSA.zip",
@@ -617,7 +700,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//seattle1/",
             "hash": "46fb75a30f0e7963e6108bdb19af4d7db4c72c3d5a020025cafa528c96e09daa",
             "filename": "SeattleMSA.zip",
-            "members": ["SeattleMSA/wa_final_census2.gpkg"]
+            "members": [
+                "SeattleMSA/wa_final_census2.gpkg"
+            ]
         },
         "seattle2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/SeattleMSA2.zip",
@@ -631,7 +716,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//seattle2/",
             "hash": "3dac2fa5b8c8dfa9dd5273a85de7281e06e18ab4f197925607f815f4e44e4d0c",
             "filename": "SeattleMSA2.zip",
-            "members": ["SeattleMSA2/SeattleMSA2.gpkg"]
+            "members": [
+                "SeattleMSA2/SeattleMSA2.gpkg"
+            ]
         },
         "sids": {
             "url": "https://geodacenter.github.io/data-and-lab//data/sids.zip",
@@ -645,7 +732,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//sids/",
             "hash": "e2f7b210b9a57839423fd170e47c02cf7a2602a480a1036bb0324e1112a4eaab",
             "filename": "sids.zip",
-            "members": ["sids/sids.gpkg"]
+            "members": [
+                "sids/sids.gpkg"
+            ]
         },
         "sids2": {
             "url": "https://geodacenter.github.io/data-and-lab//data/sids2.zip",
@@ -659,7 +748,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//sids2/",
             "hash": "b5875ffbdb261e6fa75dc4580d67111ef1434203f2d6a5d63ffac16db3a14bd0",
             "filename": "sids2.zip",
-            "members": ["sids2/sids2.gpkg"]
+            "members": [
+                "sids2/sids2.gpkg"
+            ]
         },
         "south": {
             "url": "https://geodacenter.github.io/data-and-lab//data/south.zip",
@@ -673,7 +764,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//south/",
             "hash": "8f151d99c643b187aad37cfb5c3212353e1bc82804a4399a63de369490e56a7a",
             "filename": "south.zip",
-            "members": ["south/south.gpkg"]
+            "members": [
+                "south/south.gpkg"
+            ]
         },
         "spirals": {
             "url": "https://geodacenter.github.io/data-and-lab//data/spirals.csv",
@@ -713,7 +806,9 @@
             "details": "https://geodacenter.github.io/data-and-lab//tampa1/",
             "hash": "9a7ea0746138f62aa589e8377edafea48a7b1be0cdca2b38798ba21665bfb463",
             "filename": "TampaMSA.zip",
-            "members": ["TampaMSA/tampa_final_census2.gpkg"]
+            "members": [
+                "TampaMSA/tampa_final_census2.gpkg"
+            ]
         },
         "us_sdoh": {
             "url": "https://geodacenter.github.io/data-and-lab//data/us-sdoh-2014.zip",
@@ -727,10 +822,14 @@
             "details": "https://geodacenter.github.io/data-and-lab//us-sdoh/",
             "hash": "076701725c4b67248f79c8b8a40e74f9ad9e194d3237e1858b3d20176a6562a5",
             "filename": "us-sdoh-2014.zip",
-            "members": ["us-sdoh-2014/us-sdoh-2014.shp", "us-sdoh-2014/us-sdoh-2014.dbf", "us-sdoh-2014/us-sdoh-2014.shx", "us-sdoh-2014/us-sdoh-2014.prj"]
+            "members": [
+                "us-sdoh-2014/us-sdoh-2014.shp",
+                "us-sdoh-2014/us-sdoh-2014.dbf",
+                "us-sdoh-2014/us-sdoh-2014.shx",
+                "us-sdoh-2014/us-sdoh-2014.prj"
+            ]
         }
     },
-
     "ny": {
         "bb": {
             "url": "https://www.nyc.gov/assets/planning/download/zip/data-maps/open-data/nybb_16a.zip",
@@ -744,10 +843,14 @@
             "ncols": 5,
             "hash": "a303be17630990455eb079777a6b31980549e9096d66d41ce0110761a7e2f92a",
             "filename": "nybb_16a.zip",
-            "members": ["nybb_16a/nybb.shp", "nybb_16a/nybb.shx", "nybb_16a/nybb.dbf", "nybb_16a/nybb.prj"]
+            "members": [
+                "nybb_16a/nybb.shp",
+                "nybb_16a/nybb.shx",
+                "nybb_16a/nybb.dbf",
+                "nybb_16a/nybb.prj"
+            ]
         }
     },
-
     "eea": {
         "large_rivers": {
             "url": "https://www.eea.europa.eu/data-and-maps/data/wise-large-rivers-and-large-lakes/zipped-shapefile-with-wise-large-rivers-vector-line/zipped-shapefile-with-wise-large-rivers-vector-line/at_download/file",
@@ -763,7 +866,6 @@
             "filename": "wise_large_rivers.zip"
         }
     },
-
     "abs": {
         "australia": {
             "url": "https://www.abs.gov.au/statistics/standards/australian-statistical-geography-standard-asgs-edition-3/jul2021-jun2026/access-and-downloads/digital-boundary-files/AUS_2021_AUST_SHP_GDA2020.zip",
@@ -788,11 +890,10 @@
             "nrows": 10,
             "ncols": 9,
             "details": "https://www.abs.gov.au/statistics/standards/australian-statistical-geography-standard-asgs-edition-3/jul2021-jun2026/access-and-downloads/digital-boundary-files",
-            "hash":"d9b7f735de6085b37414faf011f796dda3c7f768c55e9dce01f96e790f399a21",
+            "hash": "d9b7f735de6085b37414faf011f796dda3c7f768c55e9dce01f96e790f399a21",
             "filename": "STE_2021_AUST_SHP_GDA2020.zip"
         }
     },
-
     "naturalearth": {
         "cities": {
             "url": "https://naciscdn.org/naturalearth/110m/cultural/ne_110m_populated_places_simple.zip",
@@ -832,6 +933,125 @@
             "ncols": 4,
             "hash": "1926c621afd6ac67c3f36639bb1236134a48d82226dc675d3e3df53d02d2a3de",
             "filename": "ne_110m_land.zip"
+        }
+    },
+    "spdata": {
+        "nydata": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/NY8_bna_utm18.gpkg",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.nydata",
+            "description": "New York leukemia data taken from the data sets supporting Waller and Gotway 2004 to demonstrate spatial data import techniques.",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spData/reference/nydata.html",
+            "nrows": 281,
+            "ncols": 13,
+            "hash": "80f7814b3064824e7656c55b3cadfc82926d8e7c4337ddc274e2c54ef939bb43",
+            "filename": "NY8_bna_utm18.gpkg"
+        },
+        "auckland": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/auckland.gpkg",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.auckland",
+            "description": "Marshall's infant mortality in Auckland dataset",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spData/reference/auckland.html",
+            "nrows": 167,
+            "ncols": 5,
+            "hash": "bdef254513a90f1f3a59db6f3a1bfd70c4d905b81e4103fa0959e7d7b1b8476e",
+            "filename": "auckland.gpkg"
+        },
+        "boston": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/boston_tracts.gpkg",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.boston",
+            "description": "Boston Housing Data",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spData/reference/boston.html",
+            "nrows": 506,
+            "ncols": 37,
+            "hash": "ab883a3047d342e035c826896efaa048b4b1442b3be1f70f63c280fe154e8d3a",
+            "filename": "boston_tracts.gpkg"
+        },
+        "columbus": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/columbus.gpkg",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.columbus",
+            "description": "Columbus OH spatial analysis dataset",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spData/reference/columbus.html",
+            "nrows": 49,
+            "ncols": 21,
+            "hash": "8c7cf24780306d731b48095d10567f14c91ddb2278a976d42425c2cbe46624be",
+            "filename": "boston_tracts.gpkg"
+        },
+        "cycle_hire": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/cycle_hire.geojson",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.cycle_hire",
+            "description": "Cycle hire points in London",
+            "geometry_type": "Point",
+            "details": "https://jakubnowosad.com/spData/reference/cycle_hire.html",
+            "nrows": 742,
+            "ncols": 6,
+            "hash": "07177c46a2aba4f82f20b7584e9fac9ce9e9d157d17bf4dea04cb25d4e720edd",
+            "filename": "cycle_hire.geojson"
+        },
+        "cycle_hire_osm": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/cycle_hire_osm.geojson",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.cycle_hire_osm",
+            "description": "Cycle hire points in London from OSM",
+            "geometry_type": "Point",
+            "details": "https://jakubnowosad.com/spData/reference/cycle_hire_osm.html",
+            "nrows": 532,
+            "ncols": 6,
+            "hash": "804e7298bc5e84d6a73f212bdd19b7f3926ee0f50a3dbd957c46c07950dcc267",
+            "filename": "cycle_hire_osm.geojson"
+        },
+        "eire": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/eire.gpkg",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.eire",
+            "description": "Eire datasets",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spData/reference/eire.html",
+            "nrows": 26,
+            "ncols": 11,
+            "hash": "e8c4969a819baa6c29cc0126dbbcef33cbec0459e349f0bce4fe3f37e211d175",
+            "filename": "eire.gpkg"
+        },
+        "ncsids": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/sids.gpkg",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.ncsids",
+            "description": "North Carolina SIDS data",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spData/reference/nc.sids.html",
+            "nrows": 100,
+            "ncols": 23,
+            "hash": "67ab56c847e1524385adf3b4e67648054035d137e5fe956f96e16941bbc5a00f",
+            "filename": "sids.gpkg"
+        },
+        "wheat": {
+            "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/wheat.gpkg",
+            "license": "CC0",
+            "attribution": "spData",
+            "name": "spdata.wheat",
+            "description": "Mercer and Hall wheat yield data",
+            "geometry_type": "Polygon",
+            "details": "https://jakubnowosad.com/spData/reference/wheat.html",
+            "nrows": 500,
+            "ncols": 9,
+            "hash": "4e4c2bfd72e3abfe240155ee6952e8235ed75aa21c39868c360e95e70c39f438",
+            "filename": "wheat.gpkg"
         }
     }
 }

--- a/geodatasets/json/database.json
+++ b/geodatasets/json/database.json
@@ -986,7 +986,7 @@
             "nrows": 49,
             "ncols": 21,
             "hash": "8c7cf24780306d731b48095d10567f14c91ddb2278a976d42425c2cbe46624be",
-            "filename": "boston_tracts.gpkg"
+            "filename": "columbus.gpkg"
         },
         "cycle_hire": {
             "url": "https://github.com/Nowosad/spData/raw/refs/heads/master/inst/shapes/cycle_hire.geojson",


### PR DESCRIPTION
This adds those datasets from the R packages `spData` and `spDataLarge` that are readily available as files to download and read with geopandas. The rest seems to be generated in some form.