### PR TITLE
CI: do not fail fast

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ jobs:
     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         environment-file: [ci/latest.yaml]


### PR DESCRIPTION
Failing windows action does not allow test data step on ubuntu to finish.